### PR TITLE
Enhance the url routing

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -6,7 +6,7 @@ import { init } from './store';
 import logger from 'redux-logger';
 
 const AppEntry = () => <Provider store={ init(logger).getStore() }>
-    <Router basename={ window.location.pathname }>
+    <Router>
         <App/>
     </Router>
 </Provider>;

--- a/src/PresentationalComponents/ContentTable/ContentTable.js
+++ b/src/PresentationalComponents/ContentTable/ContentTable.js
@@ -43,7 +43,7 @@ const ContentTable = ({ data, hits }) => {
                 title: <span key={key}> {item.status === 'active' ?
                     <CheckCircleIcon color={global_palette_green_500.value} /> : <TimesCircleIcon color={global_palette_red_100.value} />}</span>
             }, {
-                title: <Link key={key} to={`${item.rule_id}`}> {item.plugin} </Link>
+                title: <Link key={key} to={`/preview/${item.rule_id}`}> {item.plugin} </Link>
             }, `${item.error_key}`, `${item.product_code}`, `${item.role}`, `${item.category}`, hits[item.rule_id] || 0]
         }] : [];
     });

--- a/src/PresentationalComponents/ErrorBoundary/ErrorBoundary.js
+++ b/src/PresentationalComponents/ErrorBoundary/ErrorBoundary.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  state = { hasError: false, error: null };
+  static getDerivedStateFromError(error) {
+    return {
+      hasError: true,
+      error
+    };
+  }
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/PresentationalComponents/LoadError/LoadError.js
+++ b/src/PresentationalComponents/LoadError/LoadError.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+    Title,
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    EmptyStatePrimary,
+} from '@patternfly/react-core';
+import BanIcon from '@patternfly/react-icons/dist/esm/icons/ban-icon';
+
+import { Link } from 'react-router-dom';
+
+const LoadDetailError = (props) => {
+    let bodyMessage;
+    if (props.bodyMessage === 'List') {
+        bodyMessage = 'Try again later. Or report issue to @insights-rule-dev';
+    } else if (props.bodyMessage === 'Detail') {
+        //No results match the given PluginName|ErrorKey in URL. Input right URL and try again.
+        bodyMessage = 'Make sure using the right PluginName|ErrorKey in URL and try again...';
+    }
+
+    return (
+        <EmptyState>
+            <EmptyStateIcon icon={BanIcon} />
+            <Title size="lg" headingLevel="h4">
+                Loading Error of {props.bodyMessage}
+            </Title>
+            <EmptyStateBody>
+                {bodyMessage}
+            </EmptyStateBody>
+            <EmptyStatePrimary>
+                Back to <Link to='/preview'>Content Preview</Link>
+            </EmptyStatePrimary>
+        </EmptyState>
+    );
+}
+
+export default LoadDetailError;

--- a/src/PresentationalComponents/LoadError/LoadError.js
+++ b/src/PresentationalComponents/LoadError/LoadError.js
@@ -16,8 +16,7 @@ const LoadDetailError = (props) => {
     if (props.bodyMessage === 'List') {
         bodyMessage = 'Try again later. Or report issue to @insights-rule-dev';
     } else if (props.bodyMessage === 'Detail') {
-        //No results match the given PluginName|ErrorKey in URL. Input right URL and try again.
-        bodyMessage = 'Make sure using the right PluginName|ErrorKey in URL and try again...';
+        bodyMessage = 'Use a right PluginName|ErrorKey in URL and try again... Or report issue to @insights-rule-dev';
     }
 
     return (

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,15 +2,29 @@ import React, { Suspense, lazy } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import Loading from './PresentationalComponents/Loading/Loading';
+import ErrorBoundary from './PresentationalComponents/ErrorBoundary/ErrorBoundary';
+import LoadError from './PresentationalComponents/LoadError/LoadError';
 
 const List = lazy(() => import(/* webpackChunkName: "List" */ './SmartComponents/Recs/List'));
 const Details = lazy(() => import(/* webpackChunkName: "Details" */ './SmartComponents/Recs/Details'));
-const paths = { list: '/preview/', details: '/preview/:recDetail' };
+const paths = { list: '/preview', details: '/preview/:recDetail' };
+
 
 export const Routes = () => <Switch>
-    <Route key='List' exact path={paths.list} rootClass='root'
-        component={() => <Suspense fallback={<Loading />}> <List /> </Suspense>} />
-    <Route key='Details' exact path={paths.details} rootClass='root'
-        component={() => <Suspense fallback={<Loading />}> <Details /> </Suspense>} />
-    <Redirect path='*' to={paths.list} push />
+    <Route exact path={paths.list}
+        component={() => (
+            <ErrorBoundary fallback={<LoadError bodyMessage='List' />}>
+                <Suspense fallback={<Loading />}> <List /> </Suspense>
+            </ErrorBoundary>
+        )}
+    />
+    <Route exact path={paths.details}
+        component={() => (
+            <ErrorBoundary fallback={<LoadError bodyMessage='Detail' />}>
+                <Suspense fallback={<Loading />}> <Details /> </Suspense>
+            </ErrorBoundary>
+        )}
+    />
+    <Redirect path='*' to={paths.list} push>
+    </Redirect>
 </Switch>;

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -146,7 +146,7 @@ const Details = ({ match, fetchContentDetails, details, fetchContentDetailsHits,
     return <div>
         <PageHeader>
             <Breadcrumb>
-                <BreadcrumbItem><Link to='./'>Content Preview</Link></BreadcrumbItem>
+                <BreadcrumbItem><Link to='/preview'>Content Preview</Link></BreadcrumbItem>
                 <BreadcrumbHeading to='#'>{`${match.params.recDetail}`}</BreadcrumbHeading>
             </Breadcrumb>
             <PageHeaderTitle title={`${details.rule_id || 'loading...'}`} />


### PR DESCRIPTION
  * Use a fixed URL for /preview and /preview/:recDetail.
  * Provide direct access to specific PluginName|ErrorKey URL.
  * For a wrong PluginName or ErrorKey in URL, show the LoadError view.