### PR TITLE
Workaround for un-loadable detail page issue

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -20,9 +20,9 @@ export const Routes = () => <Switch>
     />
     <Route exact path={paths.details}
         component={() => (
-            <ErrorBoundary fallback={<LoadError bodyMessage='Detail' />}>
+            //<ErrorBoundary fallback={<LoadError bodyMessage='Detail' />}>
                 <Suspense fallback={<Loading />}> <Details /> </Suspense>
-            </ErrorBoundary>
+            //</ErrorBoundary>
         )}
     />
     <Redirect path='*' to={paths.list} push>


### PR DESCRIPTION
  When using a right URL for detail view, the page will fall into ErrorBoundary
  error handling page unexpectly. This was noticed when using non-product host
  during frontend content development, some random reload action would trigger
  this bug.
  Workaround here is to remove this ErrorBoundary error handling temporarily.

Signed-off-by: XiaoXue Wang <xiaoxwan@redhat.com>