### PR TITLE
Import correct PF stylesheets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import './App.scss';
-import '@patternfly/react-core/dist/styles/base.css';
+import '@patternfly/patternfly/patternfly.scss';
 
 import PropTypes from 'prop-types';
 import React from 'react';


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ADVISOR-3153

This bug took me down a rabbit hole -- Advisor uses Insights Chrome which bundles all styles into [pf4-v4.css](
https://github.com/RedHatInsights/insights-chrome/blob/35e56e6a665711cfea03341d4abcbd385cda62c5/src/sass/pf-4-assets.scss). But it does not bundle the patternfly/react-core stylesheets, rather the patternfly/patternfly. So I changed this app to match it.