### PR TITLE
fix: "TypeError: Cannot read properties of undefined at ContentTable.js:37:26"

### DIFF
--- a/src/PresentationalComponents/ContentTable/ContentTable.js
+++ b/src/PresentationalComponents/ContentTable/ContentTable.js
@@ -34,7 +34,7 @@ const ContentTable = ({ data, hits }) => {
 
     const buildRows = (data) => data.flatMap((item, key) => {
         const isValidSearchText = debouncedSearchText.length === 0
-            || item.name.toLowerCase().includes(debouncedSearchText.toLowerCase())
+            // || item.name.toLowerCase().includes(debouncedSearchText.toLowerCase())
             || item.plugin.toLowerCase().includes(debouncedSearchText.toLowerCase())
             || item.error_key.toLowerCase().includes(debouncedSearchText.toLowerCase());
 


### PR DESCRIPTION
To fix "TypeError: Cannot read properties of undefined (reading 'toLowerCase') at ContentTable.js:37:26 ". Root cause is likely be that CCX rule does not have this "name" attribute. Remove this "name" search in "isValidSearchText"

![Screenshot 2023-12-22 at 09 33 50](https://github.com/RedHatInsights/content-preview/assets/13017832/95ba279d-fca5-4ea0-899c-342424dce888)

