### PR TITLE
fix: show kba link in Prod instead of Stage

### DIFF
--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -149,7 +149,9 @@ const Details = ({
         fetchContentDetails(detailName);
         fetchContentDetailsHits(detailName);
 
-        if (details.node_id !== undefined) {
+        // Skip the fetchKbaDetails when node_id is not set
+        if (details.node_id !== undefined &&                                          // node_id: null
+                typeof details.node_id === 'string' && details.node_id.length > 0) {  // node_id: ''
             fetchKbaDetails(details.node_id);
         }
     }, [

--- a/src/SmartComponents/Recs/Details.js
+++ b/src/SmartComponents/Recs/Details.js
@@ -399,6 +399,7 @@ const Details = ({
                                 }}
                                 kbaDetail={kbaDetailsData}
                                 kbaLoading={kbaLoading}
+                                isProd={true}
                             />
                         </Stack>
                     </GridItem>


### PR DESCRIPTION

 - fix: show kba as Prod in ReportDetails
 - fix: skip the fetchKba if node_id is an empty string